### PR TITLE
Simplify by making MOGReducers blocks

### DIFF
--- a/Example.md
+++ b/Example.md
@@ -19,7 +19,7 @@ MOGMapBlock SortArrayOfNumbers(BOOL ascending)
 MOGMapBlock TrimArray(NSUInteger trimN)
 {
     return ^id(NSArray *values) {
-        return [values mog_transduce:TrimTransducer(trimN, values.count - 2 * trimN)];
+        return [values mog_transform:TrimTransducer(trimN, values.count - 2 * trimN)];
     };
 }
 
@@ -54,12 +54,12 @@ NSNumber *number = MOGTransform(array, MOGLastValueReducer(), @0, filter);
 // number == 7.5
 
 // Or we can simulate the numbers coming in from a stream and manually feed numbers to the filter.
-MOGReducer *manualFilter = filter(MOGLastValueReducer());
+MOGReducer manualFilter = filter(MOGLastValueReducer());
 
 // Can compare the values of number with the result array above.
-number = manualFilter.reduce(nil, @14); // number == 14
-number = manualFilter.reduce(nil, @13); // number == 14
-number = manualFilter.reduce(nil, @12); // number == 14
-number = manualFilter.reduce(nil, @1);  // number == 14
-number = manualFilter.reduce(nil, @2);  // number == 13.83
+number = manualFilter(nil, @14); // number == 14
+number = manualFilter(nil, @13); // number == 14
+number = manualFilter(nil, @12); // number == 14
+number = manualFilter(nil, @1);  // number == 14
+number = manualFilter(nil, @2);  // number == 13.83
 ```

--- a/MogKit.xcodeproj/project.pbxproj
+++ b/MogKit.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		6313DA33E32E29B8A43571CC /* NSArrayExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DEEF661B2573A4D9037F /* NSArrayExtensionTests.m */; };
 		6313DC63CF8753FDC0CE84BC /* MogReduceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DF459141FACBF1F00FC8 /* MogReduceTests.m */; };
 		6313DCFFB7CADF1F2858B732 /* NSObjectExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313D3D5672BFEF6BC26FB82 /* NSObjectExtensionTests.m */; };
-		6313DE581DD560CBDABC45FD /* MogKitPerfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DAE43FF93B90D20954BC /* MogKitPerfTests.m */; };
 		6313DEBBA7BE3BE52606A406 /* NSArrayExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DEEF661B2573A4D9037F /* NSArrayExtensionTests.m */; };
 		6313DFFFE3764F1D4FF48757 /* NSObject+MogKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6313DBB24D124431EF1616C5 /* NSObject+MogKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		99497FBE1AAEF01700EC4E21 /* MogTransformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313D18DDF2E3A5ED92D8280 /* MogTransformation.m */; };
@@ -481,7 +480,6 @@
 				6313DA33E32E29B8A43571CC /* NSArrayExtensionTests.m in Sources */,
 				6313D83BF4DB5BED70D4B629 /* MogReduceTests.m in Sources */,
 				6313D54580BD3636890D5E9D /* NSObjectExtensionTests.m in Sources */,
-				6313DE581DD560CBDABC45FD /* MogKitPerfTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MogKit.xcodeproj/project.pbxproj
+++ b/MogKit.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		6313DA33E32E29B8A43571CC /* NSArrayExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DEEF661B2573A4D9037F /* NSArrayExtensionTests.m */; };
 		6313DC63CF8753FDC0CE84BC /* MogReduceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DF459141FACBF1F00FC8 /* MogReduceTests.m */; };
 		6313DCFFB7CADF1F2858B732 /* NSObjectExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313D3D5672BFEF6BC26FB82 /* NSObjectExtensionTests.m */; };
+		6313DE581DD560CBDABC45FD /* MogKitPerfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DAE43FF93B90D20954BC /* MogKitPerfTests.m */; };
 		6313DEBBA7BE3BE52606A406 /* NSArrayExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313DEEF661B2573A4D9037F /* NSArrayExtensionTests.m */; };
 		6313DFFFE3764F1D4FF48757 /* NSObject+MogKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6313DBB24D124431EF1616C5 /* NSObject+MogKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		99497FBE1AAEF01700EC4E21 /* MogTransformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6313D18DDF2E3A5ED92D8280 /* MogTransformation.m */; };
@@ -480,6 +481,7 @@
 				6313DA33E32E29B8A43571CC /* NSArrayExtensionTests.m in Sources */,
 				6313D83BF4DB5BED70D4B629 /* MogReduceTests.m in Sources */,
 				6313D54580BD3636890D5E9D /* NSObjectExtensionTests.m in Sources */,
+				6313DE581DD560CBDABC45FD /* MogKitPerfTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MogKit/MogReduce.h
+++ b/MogKit/MogReduce.h
@@ -8,111 +8,47 @@
 
 
 /**
- * Block that generates the initial value of a reduction.
- */
-typedef id (^MOGReducerInititialBlock) (void);
-
-/**
- * Block that is called by `MOGTransform` after a reduction is done, this to allow step functions or the
- * collection `MOGReducer` to do some final manipulation of the data.
- */
-typedef id (^MOGReducerCompleteBlock) (id);
-
-/**
- * A reduce block is passed to `MOGReduce` and is used to collect the accumulated valeu of the
+ * A reducer is passed to `MOGReduce` and is used to collect the accumulated value of the
  * reduction. The block is passed the accumulated value and the next value in order to calculate
  * the next accumulated value.
  */
-typedef id (^MOGReduceBlock) (id acc, id val);
+typedef id (^MOGReducer) (id acc, id val);
 
 /**
-* A reducer takes an accumulated value and the next value and combines them into a new accumulated value.
-* The return accumulated value is typically passed in as `acc` on successive calls.
-*/
-@interface MOGReducer : NSObject
-@property (nonatomic, copy) MOGReduceBlock reduce;
-@property (nonatomic, copy) MOGReducerInititialBlock initial;
-@property (nonatomic, copy) MOGReducerCompleteBlock complete;
-
-/**
-* Initialize a `MOGReducer` with blocks to create initial value, completion handler and reduce block.
-*
-* @discussion Use this initializer when writing an output reducer. For implementing transformations use one of the
-* stepReducer class methods instead.
-*
-* @param initBlock a block that creates the initial value for a reduction.
-* @param completeBlock block that will be called exactly once after a reduction is complete.
-* @param reduceBlock called for each value in the reduction.
-*
-* @return the reducer
-* */
-- (instancetype)initWithInitBlock:(id(^)(void))initBlock
-                    completeBlock:(id(^)(id))completeBlock
-                      reduceBlock:(MOGReduceBlock)reduceBlock;
-
-/**
- * Class method to create a step reducer (used when implementing transformations).
+ * A reducer that accumulates values in a mutable array. The user needs to make sure a `NSMutableArray` is passed in
+ * as initial value to `MOGReduce` or `MOGTransform`.
  *
- * @param reduceBlock called for each value in the reduction.
- *
- * @return a newly created step reducer.
+ * @return a reducer collecting values in a mutable array.
  */
-+ (instancetype)stepReducerWithNextReducer:(MOGReducer *)nextReducer reduceBlock:(MOGReduceBlock)reduceBlock;
-
-/**
- * Class method to create a step reducer (used when implementing transformations). Use this when the transformation
- * keeps some state that needs to be flushed after the reduction is done. See the implementation of `MOGPartition` for
- * an example of this.
- *
- * @param completeBlock block that will be called exactly once after a reduction is complete. Note that this block need
- * to chain to nextReducers completeBlock.
- * @param reduceBlock called for each value in the reduction.
- *
- * @return a newly created step reducer.
- */
-+ (instancetype)stepReducerWithNextReducer:(MOGReducer *)nextReducer
-                               reduceBlock:(MOGReduceBlock)reduceBlock
-                             completeBlock:(id(^)(id))completeBlock;
-
-@end
-
-/**
- * A reducer that accumulates values in an array. If the reducer initial block isn't used to produce the
- * initial value an `NSMutableArray` must be supplied to `MOGReduce` or `MOGTransformWithInitial`.
- *
- * When calling complete an immutable copy is returned.
- *
- * @return a reducer collecting values in an array.
- */
-MOGReducer *MOGArrayReducer(void);
+MOGReducer MOGArrayReducer(void);
 
 /**
  * A reducer that ignores the accumulated value and simply always returns the last value it received. This is useful
  * when only the final value of a computation is used.
  */
-MOGReducer *MOGLastValueReducer(void);
+MOGReducer MOGLastValueReducer(void);
 
 /**
- * A reducer that concatenates string values, with a possible separator. If the reducer initial block isn't used
- * to produce the initial value, a NSMutableString must be supplied to `MOGReduce` or `MOGTransformWithInitial`.
+ * A reducer that concatenates string values, with a possible separator. The user needs to make sure a
+ * `NSMutableString` is passed in as initial value to `MOGReduce` or `MOGTransform`.
  *
  * @param separator a separator that is inserted between each string
  *
  * @return a reducer collecting values in an array.
  */
-MOGReducer *MOGStringConcatReducer(NSString *separator);
+MOGReducer MOGStringConcatReducer(NSString *separator);
 
 /**
- * Applies the `reduceBlock` to each element of `source` and returns the final accumulated
- * value returned by `reduceBlock`.
+ * Applies the `reducer` to each element of `source` and returns the final accumulated
+ * value returned by `reducer`.
  *
  * @param source any class conforming to the `NSFastEnumeration` protocol.
- * @param reduceBlock the reduce block to collect some accumulated value.
- * @param initial the initial value passed in as accumulator to the reduce block.
+ * @param reducer the reducer block to collect some accumulated value.
+ * @param initial the initial value passed in as accumulator to the reducer.
  *
- * @return returns the final return value of `reduceBlock`.
+ * @return returns the final return value of `reducer`.
  */
-id MOGReduce(id<NSFastEnumeration> source, MOGReduceBlock reduceBlock, id initial);
+id MOGReduce(id<NSFastEnumeration> source, MOGReducer reducer, id initial);
 
 /**
  * Wraps `value` to signal that a reduction is done. `MOGReduce` will look at the value returned
@@ -127,8 +63,7 @@ id MOGReduced(id value);
 
 /**
  * Checks whether `value` is a value wrapped to indicate that the reduction is done. This is used
- * by `MOGReduce` to decide on whether it should continue with the reduction. Any implementor
- * of another transformation based process need to check the return value after each iteration.
+ * by `MOGReduce` to decide on whether it should continue with the reduction.
  *
  * @param the value to check
  *

--- a/MogKit/MogReduce.m
+++ b/MogKit/MogReduce.m
@@ -13,52 +13,40 @@
 @end
 
 
-MOGReducer *MOGArrayReducer(void)
+MOGReducer MOGArrayReducer(void)
 {
-    return [[MOGReducer alloc] initWithInitBlock:^id {
-        return [NSMutableArray new];
-    } completeBlock:^id(NSMutableArray *result) {
-        return [result copy];
-    } reduceBlock:^id(NSMutableArray *acc, id val) {
+    return ^NSMutableArray *(NSMutableArray *acc, id val) {
         [acc addObject:val];
         return acc;
-    }];
+    };
 }
 
 
-MOGReducer *MOGLastValueReducer(void)
+MOGReducer MOGLastValueReducer(void)
 {
-    return [[MOGReducer alloc] initWithInitBlock:^id {
-        return nil;
-    } completeBlock:^id(id o) {
-        return o;
-    } reduceBlock:^id(id acc, id val) {
+    return ^id(id _, id val) {
         return val;
-    }];
+    };
 }
 
-MOGReducer *MOGStringConcatReducer(NSString *separator)
+MOGReducer MOGStringConcatReducer(NSString *separator)
 {
-    return [[MOGReducer alloc] initWithInitBlock:^id {
-        return [NSMutableString new];
-    } completeBlock:^id(NSMutableString *result) {
-        return [result copy];
-    } reduceBlock:^id(NSMutableString *acc, NSString *val) {
+    return ^NSMutableString *(NSMutableString *acc, NSString *val) {
         if (!separator || [acc isEqualToString:@""]) {
             [acc appendString:val];
         } else {
             [acc appendFormat:@"%@%@", separator, val];
         }
         return acc;
-    }];
+    };
 }
 
-id MOGReduce(id<NSFastEnumeration> source, MOGReduceBlock reduceBlock, id initial)
+id MOGReduce(id<NSFastEnumeration> source, MOGReducer reducer, id initial)
 {
     id acc = initial;
 
     for (id val in source) {
-        acc = reduceBlock(acc, val);
+        acc = reducer(acc, val);
         if (MOGIsReduced(acc)) {
             acc = MOGReducedGetValue(acc);
             break;
@@ -103,39 +91,3 @@ id MOGUnreduced(id val)
 {
     return MOGIsReduced(val) ? MOGReducedGetValue(val) : val;
 }
-
-
-@implementation MOGReducer
-
-- (instancetype)initWithInitBlock:(id(^)(void))initBlock
-                    completeBlock:(id(^)(id))completeBlock
-                      reduceBlock:(MOGReduceBlock)reduceBlock
-{
-    if (self = [super init]) {
-        self.initial = initBlock;
-        self.complete = completeBlock;
-        self.reduce = reduceBlock;
-    }
-
-    return self;
-}
-
-+ (instancetype)stepReducerWithNextReducer:(MOGReducer *)nextReducer reduceBlock:(MOGReduceBlock)reduceBlock
-{
-    return [self stepReducerWithNextReducer:nextReducer
-                                reduceBlock:reduceBlock
-                              completeBlock:^id(id result) {
-                                  return nextReducer.complete(result);
-                              }];
-}
-
-+ (instancetype)stepReducerWithNextReducer:(MOGReducer *)nextReducer
-                               reduceBlock:(MOGReduceBlock)reduceBlock
-                             completeBlock:(id(^)(id))completeBlock
-{
-    return [[self alloc] initWithInitBlock:^id { return nextReducer.initial(); }
-                             completeBlock:completeBlock
-                               reduceBlock:reduceBlock];
-}
-
-@end

--- a/MogKit/MogTransformation.h
+++ b/MogKit/MogTransformation.h
@@ -15,7 +15,7 @@
  * @discussion a transformation can be stateful but the state is bound in the reducer created when the transformation
  * is applied to the output reducer. This means it's safe to use the same transformation to create new reducers.
  */
-typedef MOGReducer *(^MOGTransformation) (MOGReducer *);
+typedef MOGReducer (^MOGTransformation) (MOGReducer);
 
 /**
  * A `MOGMapBlock` is a function you typically use with `MOGMap` which is a transformation of a single value
@@ -211,26 +211,6 @@ MOGTransformation MOGFlatten(void);
 MOGTransformation MOGFlatMap(MOGMapBlock mapBlock);
 
 /**
- * Creates a transformation that splits the the values into separate `NSArray`s every time the `partitioningBlock`
- * returns a new value. The final partition will be sent on complete.
- *
- * @param partitioningBlock the return value of calling the block decides on whether a new partition should be created.
- *
- * @return a stateful transformation that splits incoming values into separate partitions.
- */
-MOGTransformation MOGPartitionBy(MOGMapBlock partitioningBlock);
-
-/**
- * Creates a transformation that splits the values into separate `NSArray`s every `size` elements. A smaller array may be
- * sent at the end if there are less values than `size` accumulated in the transformation at complete.
- *
- * @param size the partition size, must be greater than 0
- *
- * @return a stateful transformation that splits incoming values into separate partitions of size `size`.
- */
-MOGTransformation MOGPartition(NSUInteger size);
-
-/**
  * Creates a transformation that creates a window of size `length` by examining the values passed through.
  * The window will always contain the last `length` values passed through. Until `length` values have passed through
  * the window will contain the first value in all slots. Each value passed through is replaced by an array with the
@@ -274,21 +254,9 @@ MOGTransformation MOGComposeArray(NSArray *transformations);
  *
  * @param source any class conforming to the `NSFastEnumeration` protocol.
  * @param reducer the reducer to collect the transformed values into the result of this function.
- * @param transformation the transformation to apply.
- *
- * @return the final value collected by `reducer`.
- */
-id MOGTransform(id<NSFastEnumeration> source, MOGReducer *reducer, MOGTransformation transformation);
-
-/**
- * Applied the transformation to `source`. This is the step when input, transformation and output are combined
- * to transform the source values into output values based on the `reducer` and the `initial` value.
- *
- * @param source any class conforming to the `NSFastEnumeration` protocol.
- * @param reducer the reducer to collect the transformed values into the result of this function.
  * @param initial the initial value to pass as the accumulator to `reducer`.
  * @param transformation the transformation to apply.
  *
  * @return the final value collected by `reducer`.
  */
-id MOGTransformWithInitial(id<NSFastEnumeration> source, MOGReducer *reducer, id initial, MOGTransformation transformation);
+id MOGTransform(id<NSFastEnumeration> source, MOGReducer reducer, id initial, MOGTransformation transformation);

--- a/MogKit/MogTransformation.m
+++ b/MogKit/MogTransformation.m
@@ -8,28 +8,28 @@
 #import "MogTransformation.h"
 
 MOGTransformation MOGIdentity(void) {
-    return ^MOGReducer *(MOGReducer *reducer) {
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
-            return reducer.reduce(acc, val);
-        }];
+    return ^MOGReducer (MOGReducer reducer) {
+        return ^(id acc, id val) {
+            return reducer(acc, val);
+        };
     };
 }
 
 MOGTransformation MOGMap(id (^mapFunc)(id))
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
-            return reducer.reduce(acc, mapFunc(val));
-        }];
+    return ^MOGReducer (MOGReducer reducer) {
+        return ^(id acc, id val) {
+            return reducer(acc, mapFunc(val));
+        };
     };
 }
 
 MOGTransformation MOGFilter(MOGPredicate predicate)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
-            return predicate(val) ? reducer.reduce(acc, val) : acc;
-        }];
+    return ^MOGReducer (MOGReducer reducer) {
+        return ^(id acc, id val) {
+            return predicate(val) ? reducer(acc, val) : acc;
+        };
     };
 }
 
@@ -41,78 +41,78 @@ MOGTransformation MOGRemove(MOGPredicate predicate) {
 
 MOGTransformation MOGTake(NSUInteger n)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block NSUInteger taken = 0;
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+        return ^(id acc, id val) {
             if (taken++ < n) {
-                id newAcc = reducer.reduce(acc, val);
+                id newAcc = reducer(acc, val);
                 return taken == n ? MOGEnsureReduced(newAcc) : newAcc;
             } else {
                 return MOGEnsureReduced(acc);
             }
-        }];
+        };
     };
 }
 
 MOGTransformation MOGTakeWhile(MOGPredicate predicate)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block BOOL keepTaking = YES;
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+        return ^(id acc, id val) {
             if (keepTaking) {
                 keepTaking = predicate(val);
             }
 
-            return keepTaking ? reducer.reduce(acc, val) : MOGEnsureReduced(acc);
-        }];
+            return keepTaking ? reducer(acc, val) : MOGEnsureReduced(acc);
+        };
     };
 }
 
 MOGTransformation MOGTakeNth(NSUInteger n) {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block NSUInteger i = 0;
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
-            return (i++ % n == 0) ? reducer.reduce(acc, val) : acc;
-        }];
+        return ^(id acc, id val) {
+            return (i++ % n == 0) ? reducer(acc, val) : acc;
+        };
     };
 }
 
 MOGTransformation MOGDrop(NSUInteger n) {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block NSUInteger dropped = 0;
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+        return ^(id acc, id val) {
             if (dropped < n) {
                 dropped++;
                 return acc;
             }
 
-            return reducer.reduce(acc, val);
-        }];
+            return reducer(acc, val);
+        };
     };
 }
 
 MOGTransformation MOGDropWhile(MOGPredicate predicate) {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block BOOL keepDropping = YES;
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+        return ^(id acc, id val) {
             if (keepDropping) {
                 keepDropping = predicate(val);
             }
-            return keepDropping ? acc : reducer.reduce(acc, val);
-        }];
+            return keepDropping ? acc : reducer(acc, val);
+        };
     };
 }
 
 MOGTransformation MOGDropNil(void) {
-    return ^MOGReducer *(MOGReducer *reducer) {
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^id(id acc, id val) {
-            return val != nil ? reducer.reduce(acc, val) : acc;
-        }];
+    return ^MOGReducer (MOGReducer reducer) {
+        return ^id(id acc, id val) {
+            return val != nil ? reducer(acc, val) : acc;
+        };
     };
 }
 
@@ -133,52 +133,52 @@ MOGTransformation MOGMapDropNil(MOGMapBlock mapBlock) {
 }
 
 MOGTransformation MOGUnique(void) {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         NSMutableSet *seenValues = [NSMutableSet new];
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+        return ^(id acc, id val) {
             if ([seenValues containsObject:val]) {
                 return acc;
             }
 
             [seenValues addObject:val];
-            return reducer.reduce(acc, val);
-        }];
+            return reducer(acc, val);
+        };
     };
 }
 
 MOGTransformation MOGDedupe(void)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block id previous = nil;
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^id(id acc, id val) {
+        return ^id(id acc, id val) {
             if ([val isEqual:previous]) {
                 return acc;
             } else {
                 previous = val;
-                return reducer.reduce(acc, val);
+                return reducer(acc, val);
             }
-        }];
+        };
     };
 }
 
 MOGTransformation MOGFlatten(void)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+    return ^MOGReducer (MOGReducer reducer) {
+        return ^(id acc, id val) {
             if (![val conformsToProtocol:@protocol(NSFastEnumeration)]) {
                 // Leave untouched if it's not a fast enumeration
-                return reducer.reduce(acc, val);
+                return reducer(acc, val);
             }
 
-            MOGReduceBlock keepReduced = ^id(id a, id v) {
-                a = reducer.reduce(a, v);
+            MOGReducer keepReduced = ^id(id a, id v) {
+                a = reducer(a, v);
                 return MOGIsReduced(a) ? MOGReduced(a) : a;
             };
 
             return MOGReduce(val, keepReduced, acc);
-        }];
+        };
     };
 }
 
@@ -187,78 +187,13 @@ MOGTransformation MOGFlatMap(MOGMapBlock mapBlock)
     return MOGCompose(MOGMap(mapBlock), MOGFlatten());
 }
 
-MOGTransformation MOGPartitionBy(MOGMapBlock partitioningBlock) {
-    return ^MOGReducer *(MOGReducer *reducer) {
-        __block id lastPartitionKey = nil;
-        __block NSMutableArray *currentPartition = [NSMutableArray new];
-
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^id(id acc, id val) {
-            id partitionKey = partitioningBlock(val);
-            lastPartitionKey = lastPartitionKey ?: partitionKey;
-
-            if ([partitionKey isEqual:lastPartitionKey]) {
-                [currentPartition addObject:val];
-                return acc;
-            } else {
-                NSArray *finishedPartition = [currentPartition copy];
-                currentPartition = nil;
-
-                id newAcc = reducer.reduce(acc, finishedPartition);
-                if (!MOGIsReduced(newAcc)) {
-                    currentPartition = [NSMutableArray new];
-                    [currentPartition addObject:val];
-                    lastPartitionKey = partitionKey;
-                }
-                return newAcc;
-            }
-        } completeBlock:^id(id result) {
-            if (currentPartition.count > 0) {
-                result = MOGUnreduced(reducer.reduce(result, [currentPartition copy]));
-                currentPartition = nil;
-            }
-            return reducer.complete(result);
-        }];
-    };
-}
-
-MOGTransformation MOGPartition(NSUInteger size)
-{
-    NSCParameterAssert(size > 0);
-
-    return ^MOGReducer *(MOGReducer *reducer) {
-        __block NSMutableArray *currentPartition;
-
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^id(id acc, id val) {
-            if (!currentPartition) {
-                currentPartition = [NSMutableArray new];
-            }
-            [currentPartition addObject:val];
-
-            if (currentPartition.count < size) {
-                return acc;
-            } else {
-                NSArray *finishedPartition = [currentPartition copy];
-                currentPartition = nil;
-                id ret = reducer.reduce(acc, finishedPartition);
-                return ret;
-            }
-        } completeBlock:^id(id result) {
-            if (currentPartition.count > 0) {
-                result = reducer.reduce(result, [currentPartition copy]);
-            }
-
-            return reducer.complete(MOGUnreduced(result));
-        }];
-    };
-}
-
 MOGTransformation MOGWindow(NSUInteger length)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         __block BOOL firstValue = YES;
         NSMutableArray *windowedValues = [NSMutableArray arrayWithCapacity:length];
 
-        return [MOGReducer stepReducerWithNextReducer:reducer reduceBlock:^(id acc, id val) {
+        return ^(id acc, id val) {
             if (firstValue) {
                 for (NSUInteger i = 0; i < length; ++i) {
                     [windowedValues addObject:val];
@@ -269,15 +204,15 @@ MOGTransformation MOGWindow(NSUInteger length)
                 [windowedValues addObject:val];
             }
 
-            return reducer.reduce(acc, [windowedValues copy]);
-        }];
+            return reducer(acc, [windowedValues copy]);
+        };
     };
 }
 
 #pragma mark - Transducer Composition
 MOGTransformation MOGCompose(MOGTransformation f, MOGTransformation g)
 {
-    return ^MOGReducer *(MOGReducer *reducer) {
+    return ^MOGReducer (MOGReducer reducer) {
         return f(g(reducer));
     };
 }
@@ -287,14 +222,7 @@ MOGTransformation MOGComposeArray(NSArray *transducers)
     return MOGReduce(transducers, ^id(id f, id g) { return MOGCompose(f, g); }, MOGIdentity());
 }
 
-id MOGTransform(id<NSFastEnumeration> source, MOGReducer *reducer, MOGTransformation transformation)
+id MOGTransform(id<NSFastEnumeration> source, MOGReducer reducer, id initial, MOGTransformation transformation)
 {
-    return MOGTransformWithInitial(source, reducer, nil, transformation);
-}
-
-id MOGTransformWithInitial(id<NSFastEnumeration> source, MOGReducer *reducer, id initial, MOGTransformation transformation)
-{
-    MOGReducer *tr = transformation(reducer);
-    initial = initial ?: tr.initial();
-    return tr.complete(MOGReduce(source, tr.reduce, initial));
+    return MOGReduce(source, transformation(reducer), initial);
 }

--- a/MogKit/NSArray+MogKit.m
+++ b/MogKit/NSArray+MogKit.m
@@ -12,13 +12,13 @@
 
 - (NSArray *)mog_transform:(MOGTransformation)transformation
 {
-    return MOGTransform(self, MOGArrayReducer(), transformation);
+    return [MOGTransform(self, MOGArrayReducer(), [NSMutableArray new], transformation) copy];
 }
 
 + (NSArray *)mog_transformedArrayFromEnumeration:(id<NSFastEnumeration>)enumeration
                                   transformation:(MOGTransformation)transformation
 {
-    return MOGTransform(enumeration, MOGArrayReducer(), transformation);
+    return [MOGTransform(enumeration, MOGArrayReducer(), [NSMutableArray new], transformation) copy];
 }
 
 @end

--- a/MogKit/NSObject+MogKit.h
+++ b/MogKit/NSObject+MogKit.h
@@ -16,9 +16,10 @@
  *
  * @param transformation the transformation to apply to the object.
  * @param reducer the reducer to use for collecting the result.
+ * @param initial the initial value passed into the transformation as accumulated value.
  *
  * @return the transformed value.
  */
-- (id)mog_transform:(MOGTransformation)transformation reducer:(MOGReducer *)reducer;
+- (id)mog_transform:(MOGTransformation)transformation reducer:(MOGReducer)reducer initial:(id)initial;
 
 @end

--- a/MogKit/NSObject+MogKit.m
+++ b/MogKit/NSObject+MogKit.m
@@ -9,10 +9,10 @@
 
 @implementation NSObject (MogKit)
 
-- (id)mog_transform:(MOGTransformation)transformation reducer:(MOGReducer *)reducer
+- (id)mog_transform:(MOGTransformation)transformation reducer:(MOGReducer)reducer initial:(id)initial
 {
-    MOGReducer *xformReducer = transformation(reducer);
-    return xformReducer.complete(xformReducer.reduce(xformReducer.initial(), self));
+    MOGReducer xformReducer = transformation(reducer);
+    return xformReducer(initial, self);
 }
 
 @end

--- a/MogKitTests/MogKitPerfTests.m
+++ b/MogKitTests/MogKitPerfTests.m
@@ -80,7 +80,7 @@
 
         MOGTransformation xform = MOGComposeArray(transducers);
 
-        NSArray *result = MOGTransform(array, MOGArrayReducer(), xform);
+        NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], xform);
 
         XCTAssertEqualObjects(array, result);
     }];
@@ -91,13 +91,13 @@
     NSArray *array = [self arrayWithInts:100000];
 
     [self measureBlock:^{
-        NSMutableArray *array1 = MOGTransform(array, MOGArrayReducer(), MOGMap(^id(NSNumber *number) {
+        NSMutableArray *array1 = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGMap(^id(NSNumber *number) {
             return @(number.intValue + 100);
         }));
-        NSMutableArray *array2 = MOGTransform(array1, MOGArrayReducer(), MOGFilter(^BOOL(NSNumber *number) {
+        NSMutableArray *array2 = MOGTransform(array1, MOGArrayReducer(), [NSMutableArray new], MOGFilter(^BOOL(NSNumber *number) {
             return YES;
         }));
-        NSMutableArray *result = MOGTransform(array2, MOGArrayReducer(), MOGMap(^id(NSNumber *number) {
+        NSMutableArray *result = MOGTransform(array2, MOGArrayReducer(), [NSMutableArray new], MOGMap(^id(NSNumber *number) {
             return @(number.intValue - 100);
         }));
 

--- a/MogKitTests/MogReduceTests.m
+++ b/MogKitTests/MogReduceTests.m
@@ -9,34 +9,24 @@
 
 - (void)testArrayReducerInitializeWithEmptyMutableArray
 {
-    MOGReducer *reducer = MOGArrayReducer();
+    MOGReducer reducer = MOGArrayReducer();
 
-    NSMutableArray *mArray = reducer.initial();
+    NSMutableArray *mArray = [NSMutableArray new];
     NSArray *expected = @[];
 
     XCTAssert([mArray isKindOfClass:[NSMutableArray class]]);
     XCTAssertEqualObjects(expected, mArray);
 }
 
-- (void)testArrayReducerCompleteCompleteDoesntChangeTheValues
-{
-    MOGReducer *reducer = MOGArrayReducer();
-    NSMutableArray *mArray = [NSMutableArray arrayWithArray:@[@1, @2, @3, @4, @5]];
-
-    NSArray *result = reducer.complete(mArray);
-
-    XCTAssert([result isKindOfClass:[NSArray class]]);
-    XCTAssertEqualObjects(result, mArray);
-}
 
 - (void)testArrayReducerReduceAddsObjects
 {
-    MOGReducer *reducer = MOGArrayReducer();
+    MOGReducer reducer = MOGArrayReducer();
 
-    NSMutableArray *mArray = reducer.initial();
+    NSMutableArray *mArray = [NSMutableArray new];
 
-    mArray = reducer.reduce(mArray, @1);
-    mArray = reducer.reduce(mArray, @2);
+    mArray = reducer(mArray, @1);
+    mArray = reducer(mArray, @2);
 
     NSArray *expected = @[@1, @2];
 
@@ -45,52 +35,32 @@
 
 - (void)testLastValueResolverReturnsVal
 {
-    MOGReducer *reducer = MOGLastValueReducer();
+    MOGReducer reducer = MOGLastValueReducer();
 
     id aString = @"aString";
 
-    XCTAssertEqualObjects(@1, reducer.reduce(nil, @1));
-    XCTAssertEqualObjects(aString, reducer.reduce(@123, aString));
-}
-
-- (void)testLastValueResolverDoesntChangeResultValue
-{
-    MOGReducer *reducer = MOGLastValueReducer();
-
-    XCTAssertEqualObjects(@99, reducer.complete(@99));
+    XCTAssertEqualObjects(@1, reducer(nil, @1));
+    XCTAssertEqualObjects(aString, reducer(@123, aString));
 }
 
 - (void)testStringConcatReducerInitializeWithEmptyMutableString
 {
-    MOGReducer *reducer = MOGStringConcatReducer(nil);
+    MOGReducer reducer = MOGStringConcatReducer(nil);
 
-    NSMutableString *mString = reducer.initial();
+    NSMutableString *mString = [NSMutableString new];
     NSString *expected = @"";
 
     XCTAssert([mString isKindOfClass:[NSMutableString class]]);
     XCTAssertEqualObjects(expected, mString);
 }
 
-- (void)testStringConcatReducerCompleteDoesntChangeTheValues
-{
-    MOGReducer *reducer = MOGStringConcatReducer(nil);
-
-    NSMutableString *mString = [[NSMutableString alloc] initWithString:@"a string"];
-
-    NSString *expected = @"a string";
-    NSString *result = reducer.complete(mString);
-
-    XCTAssert([result isKindOfClass:[NSString class]]);
-    XCTAssertEqualObjects(expected, result);
-}
-
 - (void)testStringConcatReducerReduceConcats
 {
-    MOGReducer *reducer = MOGStringConcatReducer(nil);
+    MOGReducer reducer = MOGStringConcatReducer(nil);
 
-    NSMutableString *acc = reducer.initial();
-    acc = reducer.reduce(acc, @"abc");
-    acc = reducer.reduce(acc, @"def");
+    NSMutableString *acc = [NSMutableString new];
+    acc = reducer(acc, @"abc");
+    acc = reducer(acc, @"def");
 
     NSString *expected = @"abcdef";
 
@@ -99,11 +69,11 @@
 
 - (void)testStringConcatReducerSupportsSeparator
 {
-    MOGReducer *reducer = MOGStringConcatReducer(@", ");
+    MOGReducer reducer = MOGStringConcatReducer(@", ");
 
-    NSMutableString *acc = reducer.initial();
-    acc = reducer.reduce(acc, @"part 1");
-    acc = reducer.reduce(acc, @"part 2");
+    NSMutableString *acc = [NSMutableString new];
+    acc = reducer(acc, @"part 1");
+    acc = reducer(acc, @"part 2");
 
     NSString *expected = @"part 1, part 2";
 

--- a/MogKitTests/MogTransformationTests.m
+++ b/MogKitTests/MogTransformationTests.m
@@ -18,14 +18,13 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@1, @2, @3, @4, @5];
 
-    MOGReducer *reducer = MOGArrayReducer();
-    reducer.reduce = ^id(NSMutableArray *acc, NSNumber *val) {
+    MOGReducer reducer = ^id(NSMutableArray *acc, NSNumber *val) {
         [acc addObject:val];
 
         return val.intValue == 5 ? MOGReduced(acc) : acc;
     };
 
-    NSArray *result = MOGTransform(array, reducer, MOGIdentity());
+    NSArray *result = MOGTransform(array, reducer, [NSMutableArray new], MOGIdentity());
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -34,7 +33,7 @@
 {
     NSArray *array = @[@1, @2, @3, @4];
     NSArray *expected = @[@11, @12, @13, @14];
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGMap(^id(NSNumber *number) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGMap(^id(NSNumber *number) {
         return @(number.intValue + 10);
     }));
 
@@ -45,24 +44,9 @@
 {
     NSArray *array = @[];
     NSArray *expected = @[];
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGMap(^id(id o) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGMap(^id(id o) {
         return o;
     }));
-
-    XCTAssertEqualObjects(expected, result);
-}
-
-- (void)testTransduceWithInitialValue
-{
-    NSArray *array = @[@1, @2, @3];
-    NSArray *expected = @[@111, @222, @333, @11, @12, @13];
-
-    NSMutableArray *initialArray = [NSMutableArray arrayWithArray:@[@111, @222, @333]];
-
-    NSArray *result = MOGTransformWithInitial(array, MOGArrayReducer(), initialArray,
-                                              MOGMap(^id(NSNumber *val) {
-                                                  return @(val.intValue + 10);
-                                              }));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -71,7 +55,7 @@
 {
     NSArray *array = @[@1, @10, @15, @20];
     NSArray *expected = @[@10, @15];
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGFilter(^BOOL(NSNumber *number) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGFilter(^BOOL(NSNumber *number) {
         int n = number.intValue;
         return n >= 10 && n <= 15;
     }));
@@ -83,7 +67,7 @@
 {
     NSArray *array = @[@1, @10, @15, @20];
     NSArray *expected = @[@1, @20];
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGRemove(^BOOL(NSNumber *number) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGRemove(^BOOL(NSNumber *number) {
         int n = number.intValue;
         return n >= 10 && n <= 15;
     }));
@@ -96,7 +80,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@1, @2, @3, @4, @5];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGTake(5));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGTake(5));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -106,7 +90,7 @@
     NSArray *array = @[@1, @2];
     NSArray *expected = @[];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGTake(0));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGTake(0));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -118,10 +102,10 @@
 
     MOGTransformation takingFive = MOGTake(5);
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), takingFive);
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], takingFive);
     XCTAssertEqualObjects(expected, result);
 
-    result = MOGTransform(array, MOGArrayReducer(), takingFive);
+    result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], takingFive);
     XCTAssertEqualObjects(expected, result);
 }
 
@@ -130,7 +114,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@1, @2, @3, @4];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGTakeWhile(^BOOL(NSNumber *number) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGTakeWhile(^BOOL(NSNumber *number) {
         return number.intValue % 5 != 0;
     }));
 
@@ -142,7 +126,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@1, @4, @7, @10];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGTakeNth(3));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGTakeNth(3));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -152,7 +136,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@4, @5, @6, @7, @8, @9, @10];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGDrop(3));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGDrop(3));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -162,7 +146,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@5, @6, @7, @8, @9, @10];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGDropWhile(^BOOL(NSNumber *number) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGDropWhile(^BOOL(NSNumber *number) {
         return number.intValue % 5 != 0;
     }));
 
@@ -183,7 +167,7 @@
             }),
             MOGDropNil());
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), dropNil);
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], dropNil);
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -195,7 +179,7 @@
 
     NSDictionary *replacementDict = @{ @"1" : @"a", @"2": @"b", @"3" : @"c", @"4" : @"d", @"5" : @"e" };
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGReplace(replacementDict));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGReplace(replacementDict));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -207,7 +191,7 @@
 
     NSDictionary *replacementDict = @{ @"1" : @"a", @"3" : @"c", @"5" : @"e" };
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGReplace(replacementDict));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGReplace(replacementDict));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -219,7 +203,7 @@
 
     NSDictionary *replacementDict = @{ @"1" : @"a", @"3" : @"c", @"5" : @"e" };
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGReplaceWithDefault(replacementDict, @"-"));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGReplaceWithDefault(replacementDict, @"-"));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -231,7 +215,7 @@
 
     NSDictionary *replacementDict = @{ @"1" : @"a", @"3" : @"c", @"5" : @"e" };
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGReplaceWithDefault(replacementDict, nil));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGReplaceWithDefault(replacementDict, nil));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -241,7 +225,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
     NSArray *expected = @[@11, @13, @15, @17, @19];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGMapDropNil(^id(NSNumber *number) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGMapDropNil(^id(NSNumber *number) {
         return number.intValue % 2 == 0 ? nil : @(number.intValue + 10);
     }));
 
@@ -253,7 +237,7 @@
     NSArray *array = @[@1, @2, @3, @4, @3, @2, @1, @8, @9, @10];
     NSArray *expected = @[@1, @2, @3, @4, @8, @9, @10];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGUnique());
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGUnique());
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -263,7 +247,7 @@
     NSArray *array = @[@1, @2, @2, @3, @4, @4, @4, @5, @4, @1];
     NSArray *expected = @[@1, @2, @3, @4, @5, @4, @1];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGDedupe());
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGDedupe());
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -273,7 +257,7 @@
     NSArray *array = @[@[@1, @2], @[@3, @4, @5], @[@6]];
     NSArray *expected = @[@1, @2, @3, @4, @5, @6];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGFlatten());
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGFlatten());
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -283,7 +267,7 @@
     NSArray *array = @[@1, @[@2, @3], @4, @5];
     NSArray *expected = @[@1, @2, @3, @4, @5];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGFlatten());
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGFlatten());
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -293,7 +277,7 @@
     NSArray *array = @[@1, @2, @3];
     NSArray *expected = @[@1, @1, @1, @2, @2, @2, @3, @3, @3];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGFlatMap(^id(id val) {
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGFlatMap(^id(id val) {
         return @[val, val, val];
     }));
 
@@ -305,68 +289,13 @@
     NSArray *array = @[@[@1, @2, @3], @[@4, @5, @6], @[@7, @8, @9, @10]];
     NSArray *expected = @[@1, @2, @3, @4, @5];
 
-    MOGReducer *reducer = MOGArrayReducer();
-    reducer.reduce = ^id(NSMutableArray *acc, NSNumber *val) {
+    MOGReducer reducer = ^id(NSMutableArray *acc, NSNumber *val) {
         [acc addObject:val];
 
         return val.intValue == 5 ? MOGReduced(acc) : acc;
     };
 
-    NSArray *result = MOGTransform(array, reducer, MOGFlatten());
-
-    XCTAssertEqualObjects(expected, result);
-}
-
-- (void)testPartitioningByTransformation
-{
-    NSArray *array = @[@1, @1, @2, @2, @3, @1];
-    NSArray *expected = @[@[@1, @1], @[@2, @2], @[@3], @[@1]];
-
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGPartitionBy(^id(id val) {
-        return val;
-    }));
-
-    XCTAssertEqualObjects(expected, result);
-}
-
-- (void)testPartitionByWithEarlyTermination
-{
-    NSArray *array = @[@1, @1, @2, @2, @3];
-    NSArray *expected = @[@[@1, @1], @[@2, @2]];
-
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGCompose(MOGPartitionBy(^id(id val) {
-        return val;
-    }), MOGTake(2)));
-
-    XCTAssertEqualObjects(expected, result);
-}
-
-- (void)testPartitionTransformation
-{
-    NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10];
-    NSArray *expected = @[@[@1, @2], @[@3, @4], @[@5, @6], @[@7, @8], @[@9, @10]];
-
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGPartition(2));
-
-    XCTAssertEqualObjects(expected, result);
-}
-
-- (void)testPartitionWithNonFinishedPartition
-{
-    NSArray *array = @[@1, @2, @3, @4, @5, @6, @7, @8];
-    NSArray *expected = @[@[@1, @2, @3], @[@4, @5, @6], @[@7, @8]];
-
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGPartition(3));
-
-    XCTAssertEqualObjects(expected, result);
-}
-
-- (void)testPartitionWithEarlyTermination
-{
-    NSArray *array = @[@1, @2, @3, @4, @5];
-    NSArray *expected = @[@[@1, @2], @[@3, @4]];
-
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGCompose(MOGPartition(2), MOGTake(2)));
+    NSArray *result = MOGTransform(array, reducer, [NSMutableArray new], MOGFlatten());
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -376,7 +305,7 @@
     NSArray *array = @[@1];
     NSArray *expected = @[@[@1, @1, @1]];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGWindow(3));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGWindow(3));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -386,7 +315,7 @@
     NSArray *array = @[@1, @2];
     NSArray *expected = @[@[@1, @1, @1], @[@1, @1, @2]];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGWindow(3));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGWindow(3));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -396,7 +325,7 @@
     NSArray *array = @[@1, @2, @3, @4, @5];
     NSArray *expected = @[@[@1, @1, @1], @[@1, @1, @2], @[@1, @2, @3], @[@2, @3, @4], @[@3, @4, @5]];
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), MOGWindow(3));
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], MOGWindow(3));
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -417,7 +346,7 @@
             })
     );
 
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), xform);
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], xform);
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -438,7 +367,7 @@
             })
     ];
     MOGTransformation xform = MOGComposeArray(transformations);
-    NSArray *result = MOGTransform(array, MOGArrayReducer(), xform);
+    NSArray *result = MOGTransform(array, MOGArrayReducer(), [NSMutableArray new], xform);
 
     XCTAssertEqualObjects(expected, result);
 }

--- a/MogKitTests/NSObjectExtensionTests.m
+++ b/MogKitTests/NSObjectExtensionTests.m
@@ -32,7 +32,7 @@
     id object = @[@1, @2, @3];
     NSArray *expected = @[@34, @35, @36];
 
-    NSArray *result = [object mog_transform:[self filterFastEnumFlattenAndAdd33] reducer:MOGArrayReducer()];
+    NSArray *result = [object mog_transform:[self filterFastEnumFlattenAndAdd33] reducer:MOGArrayReducer() initial:[NSMutableArray new]];
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -42,7 +42,7 @@
     id object = @1;
     NSArray *expected = @[];
 
-    NSArray *result = [object mog_transform:[self filterFastEnumFlattenAndAdd33] reducer:MOGArrayReducer()];
+    NSArray *result = [object mog_transform:[self filterFastEnumFlattenAndAdd33] reducer:MOGArrayReducer() initial:[NSMutableArray new]];
 
     XCTAssertEqualObjects(expected, result);
 }
@@ -54,7 +54,7 @@
 
     NSArray *result = [object mog_transform:MOGFlatMap(^id(NSNumber *number) {
         return @[@(-number.intValue), @0, number];
-    }) reducer:MOGArrayReducer()];
+    }) reducer:MOGArrayReducer() initial:[NSMutableArray new]];
 
     XCTAssertEqualObjects(expected, result);
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or work on some numbers and output as a string:
 ```objective-c
 NSArray *array = @[@1, @2, @3];
 
-NSString *result = MOGTransform(array, MOGStringConcatReducer(@", "), MOGCompose(MOGMap(^id(NSNumber *val) {
+NSString *result = MOGTransform(array, MOGStringConcatReducer(@", "), [NSMutableString new], MOGCompose(MOGMap(^id(NSNumber *val) {
     return @(val.intValue + 10);
 }), MOGMap(^id(NSNumber *val) {
     return val.stringValue;
@@ -42,7 +42,7 @@ NSArray *expected = @[@(-10), @0, @10];
 
 NSArray *result = [object mog_transform:MOGFlatMap(^id(NSNumber *number) {
     return @[@(-number.intValue), @0, number];
-}) reducer:MOGArrayReducer()];
+}) reducer:MOGArrayReducer() initial:[NSMutableArray new]];
 
 // result = @[@(-10), @0, @10]
 ```
@@ -84,15 +84,15 @@ Using MogKit isn't limited to containers implementing `NSFastEnumeration`. You c
         return [class return:val];
     }));
 
-    MOGReducer *reducer = transformationWithMapToRAC(MOGArrayReducer());
+    MOGReducer reducer = transformationWithMapToRAC(MOGArrayReducer());
 
     return [[self bind:^{
         return ^(id value, BOOL *stop) {
-            id acc = reducer.reduce(reducer.initial(), value);
+            id acc = reducer([NSMutableArray new], value);
 
             if (MOGIsReduced(acc)) {
                 *stop = YES;
-                acc = reducer.complete(MOGReducedGetValue(acc));
+                acc = MOGReducedGetValue(acc);
             }
             return [class concat:acc];
         };
@@ -143,8 +143,6 @@ The transformation can then be reused and is not even tied to `RACStream`.
 - Dedupe
 - Flatten
 - FlatMap
-- PartitionBy
-- Partition
 - Window
 
 ## Installation


### PR DESCRIPTION
:warning: Only for consideration. :warning: 

In order to support processes were values are accumulated in the process
to be passed on in chunks or when the process finish `MOGReducer` was made
into an object with initial, reduce and complete blocks.

When the process is finished complete was called to allow the process to
flush any internal buffers. While this makes it more powerful it also
makes makes the implementation more complex and adds to the concepts
required to be known by the user.

Another drawback is that it makes it more cumbersome to supply a user
defined reducer since an object needs to be created with the reduce
block set.

While the last paragraph is a benefit of dropping the MOGReducer class
and simply make it into a `(C, A) -> A` block, using a class had the
benefit of make the accumulator type opaque for the user of the shipped
reducers (`MOGArrayReducer` etc).
