### PR TITLE
Use stop parameter instead of MOGReduced.

### DIFF
--- a/MogKit/MogReduce.h
+++ b/MogKit/MogReduce.h
@@ -22,6 +22,8 @@ typedef id (^MOGReducerCompleteBlock) (id);
  * A reduce block is passed to `MOGReduce` and is used to collect the accumulated value of the
  * reduction. The block is passed the accumulated value and the next value in order to calculate
  * the next accumulated value.
+ *
+ * Set stop to YES to terminate the reduction.
  */
 typedef id (^MOGReduceBlock) (id acc, id val, BOOL *stop);
 

--- a/MogKit/MogReduce.h
+++ b/MogKit/MogReduce.h
@@ -19,11 +19,11 @@ typedef id (^MOGReducerInititialBlock) (void);
 typedef id (^MOGReducerCompleteBlock) (id);
 
 /**
- * A reduce block is passed to `MOGReduce` and is used to collect the accumulated valeu of the
+ * A reduce block is passed to `MOGReduce` and is used to collect the accumulated value of the
  * reduction. The block is passed the accumulated value and the next value in order to calculate
  * the next accumulated value.
  */
-typedef id (^MOGReduceBlock) (id acc, id val);
+typedef id (^MOGReduceBlock) (id acc, id val, BOOL *stop);
 
 /**
 * A reducer takes an accumulated value and the next value and combines them into a new accumulated value.
@@ -113,53 +113,3 @@ MOGReducer *MOGStringConcatReducer(NSString *separator);
  * @return returns the final return value of `reduceBlock`.
  */
 id MOGReduce(id<NSFastEnumeration> source, MOGReduceBlock reduceBlock, id initial);
-
-/**
- * Wraps `value` to signal that a reduction is done. `MOGReduce` will look at the value returned
- * after each iteration to decide on whether the process has completed. If so, it will unwrap the
- * value with `MOGReducedGetValue` and return it.
- *
- * @param the value to wrap
- *
- * @return a reduced value to indicate that the reduction is done.
- */
-id MOGReduced(id value);
-
-/**
- * Checks whether `value` is a value wrapped to indicate that the reduction is done. This is used
- * by `MOGReduce` to decide on whether it should continue with the reduction. Any implementor
- * of another transformation based process need to check the return value after each iteration.
- *
- * @param the value to check
- *
- * @return YES if `value` is a reduced value.
- */
-BOOL MOGIsReduced(id value);
-
-/**
- * Unwraps the value from the reduced wrapped and returns it.
- *
- * @param the reduced value
- *
- * @return the unwrapped original value.
- */
-id MOGReducedGetValue(id reducedValue);
-
-/**
- * Ensures that a value is wrapped as a reduced value. If `val` is already reduced, it's
- * returned, otherwise it's wrapped as reduced.
- *
- * @param val the value
- *
- * @return a reduced value
- */
-id MOGEnsureReduced(id val);
-
-/**
- * If `val` is reduced, it's unwrapped, otherwise it's returned.
- *
- * @param val the possibly reduced value.
- *
- * @return a possibly unwrapped value.
- */
-id MOGUnreduced(id val);

--- a/MogKit/NSObject+MogKit.m
+++ b/MogKit/NSObject+MogKit.m
@@ -12,7 +12,8 @@
 - (id)mog_transform:(MOGTransformation)transformation reducer:(MOGReducer *)reducer
 {
     MOGReducer *xformReducer = transformation(reducer);
-    return xformReducer.complete(xformReducer.reduce(xformReducer.initial(), self));
+    BOOL stop = NO;
+    return xformReducer.complete(xformReducer.reduce(xformReducer.initial(), self, &stop));
 }
 
 @end

--- a/MogKitTests/MogReduceTests.m
+++ b/MogKitTests/MogReduceTests.m
@@ -34,9 +34,10 @@
     MOGReducer *reducer = MOGArrayReducer();
 
     NSMutableArray *mArray = reducer.initial();
+    BOOL stop = NO;
 
-    mArray = reducer.reduce(mArray, @1);
-    mArray = reducer.reduce(mArray, @2);
+    mArray = reducer.reduce(mArray, @1, &stop);
+    mArray = reducer.reduce(mArray, @2, &stop);
 
     NSArray *expected = @[@1, @2];
 
@@ -48,9 +49,10 @@
     MOGReducer *reducer = MOGLastValueReducer();
 
     id aString = @"aString";
+    BOOL stop = NO;
 
-    XCTAssertEqualObjects(@1, reducer.reduce(nil, @1));
-    XCTAssertEqualObjects(aString, reducer.reduce(@123, aString));
+    XCTAssertEqualObjects(@1, reducer.reduce(nil, @1, &stop));
+    XCTAssertEqualObjects(aString, reducer.reduce(@123, aString, &stop));
 }
 
 - (void)testLastValueResolverDoesntChangeResultValue
@@ -89,8 +91,10 @@
     MOGReducer *reducer = MOGStringConcatReducer(nil);
 
     NSMutableString *acc = reducer.initial();
-    acc = reducer.reduce(acc, @"abc");
-    acc = reducer.reduce(acc, @"def");
+    BOOL stop = NO;
+
+    acc = reducer.reduce(acc, @"abc", &stop);
+    acc = reducer.reduce(acc, @"def", &stop);
 
     NSString *expected = @"abcdef";
 
@@ -102,8 +106,10 @@
     MOGReducer *reducer = MOGStringConcatReducer(@", ");
 
     NSMutableString *acc = reducer.initial();
-    acc = reducer.reduce(acc, @"part 1");
-    acc = reducer.reduce(acc, @"part 2");
+    BOOL stop = NO;
+
+    acc = reducer.reduce(acc, @"part 1", &stop);
+    acc = reducer.reduce(acc, @"part 2", &stop);
 
     NSString *expected = @"part 1, part 2";
 


### PR DESCRIPTION
Instead of wrapping the return value in a MOGReduced object, add a stop
parameter to MOGReduceBlock and check that to see if the reduction
should terminate early.

It makes the implementation easier and the API clearer.

Fixes #16
